### PR TITLE
add failing test for diff.EmitFull with diff.IgnoreUnexported(true)

### DIFF
--- a/option_test.go
+++ b/option_test.go
@@ -33,3 +33,12 @@ func TestEqualNaN(t *testing.T) {
 		})
 	}
 }
+
+func TestEmitFullWithUnexportedPanic(t *testing.T) {
+	a := struct{ v []int }{nil}
+	b := struct{ v []int }{[]int{}}
+	diff.Each(t.Logf, a, b,
+		diff.EmitFull,
+		diff.IgnoreUnexported(false),
+	)
+}


### PR DESCRIPTION
I wrote a test using diff  (using Picky) to compare two structs with equal underlying types that had an unexported field of a slice. I expected to see diff output the differences between the slices, but instead saw this panic:

```
diff % go test -trimpath
--- FAIL: TestEmitFullWithUnexportedPanic (0.00s)
panic: reflect.Value.Interface: cannot return value obtained from unexported field or method [recovered]
	panic: reflect.Value.Interface: cannot return value obtained from unexported field or method

goroutine 173 [running]:
testing.tRunner.func1.2({0x100511920, 0x100534a50})
	testing/testing.go:1390 +0x1c8
testing.tRunner.func1()
	testing/testing.go:1393 +0x384
panic({0x100511920, 0x100534a50})
	runtime/panic.go:838 +0x204
reflect.valueInterface({0x100511160?, 0x140001cf738?, 0x2?}, 0x1c?)
	reflect/value.go:1441 +0xcc
reflect.Value.Interface(...)
	reflect/value.go:1430
kr.dev/diff.reflectAny(...)
	kr.dev/diff/diff.go:352
kr.dev/diff.(*printEmitter).emitf(0x140001e7a70, {0x100511160?, 0x140001cf738?, 0x2?}, {0x100511160?, 0x140001cf740?, 0x1?}, {0x1004d1925, 0x8}, {0x140001daf80, ...})
	kr.dev/diff/diff.go:87 +0x130
kr.dev/diff.eqtest[...]({0x100535498, 0x140001e7a70}, {0x100511160, 0x140001cf738?, 0x100471d50?}, {0x100511160?, 0x140001cf740?, 0x14000121008?}, 0x1?, 0x3)
	kr.dev/diff/diff.go:310 +0x130
kr.dev/diff.(*differ).walk(0x140001e7920, {0x100535498, 0x140001e7a70}, {0x100511160?, 0x140001cf738?, 0x320?}, {0x100511160?, 0x140001cf740?, 0xfffffffffffffffd?}, 0x1)
	kr.dev/diff/diff.go:278 +0x998
kr.dev/diff.(*differ).walk(0x140001e7920, {0x100535498, 0x140001e7a40}, {0x10050f5a0?, 0x140001c8ea0?, 0x140001d0e01?}, {0x10050f5a0?, 0x140001c8eb8?, 0x14000064e58?}, 0x1)
	kr.dev/diff/diff.go:272 +0x1f9c
kr.dev/diff.(*differ).walk(0x140001e7920, {0x100535498, 0x140001e7a10}, {0x100519da0?, 0x140001c8ea0?, 0x99?}, {0x100519da0?, 0x140001c8eb8?, 0x99?}, 0x1)
	kr.dev/diff/diff.go:220 +0x2304
kr.dev/diff.Each(0x140001d14b0, {0x100519da0, 0x140001c8ea0}, {0x100519da0?, 0x140001c8eb8}, {0x140001d14c0, 0x2, 0x2})
	kr.dev/diff/diff.go:26 +0x370
kr.dev/diff_test.TestEmitFullWithUnexportedPanic(0x140001f3ba0)
	kr.dev/diff/option_test.go:40 +0x17c
testing.tRunner(0x140001f3ba0, 0x100534190)
	testing/testing.go:1440 +0x110
created by testing.(*T).Run
	testing/testing.go:1487 +0x300
exit status 2
FAIL	kr.dev/diff	0.298s
```

The panic trace leads to:

```
// reflectAny is like rv.Interface(), but it returns untyped nil
// for the zero Value.
func reflectAny(rv reflect.Value) any {
        if !rv.IsValid() {
                return nil                 
        }
        // Note, Interface panics if rv was obtained from an unexported field.
        // We intend that never to happen here so a panic is appropriate.      
        return rv.Interface() // <--- HERE
}                   
```

I'm submitting this PR as more of an issue because issues on the repo are closed, and I'm not confident my only solution is the best: panic/log a helpful error if the two options are used together. I'm assuming there is a fix that doesn't require such an abrupt halt and if a halt is needed at all.