### PR TITLE
use actual type in slice diff output

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -456,7 +456,7 @@ func (d *differ) seqDiff(e emitfer, as, bs reflect.Value) {
 			}
 			continue
 		}
-		ee := e.subf(reflectString, "[%d:%d]", a0, a1)
+		ee := e.subf(as.Type(), "[%d:%d]", a0, a1)
 		afmt := formatShort(as.Slice(a0, a1), false)
 		bfmt := formatShort(bs.Slice(b0, b1), false)
 		ee.emitf("%v != %v", afmt, bfmt)

--- a/diff_test.go
+++ b/diff_test.go
@@ -311,6 +311,18 @@ func TestLog(t *testing.T) {
 	}
 }
 
+func TestSliceType(t *testing.T) {
+	var got string
+	gotp := (*stringPrinter)(&got)
+	a := []struct{}{{}, {}, {}}
+	b := []struct{}{{}, {}}
+	diff.Each(gotp.Printf, a, b)
+	want := "[]struct{}[2:3]: {{}} != {}\n"
+	if got != want {
+		t.Errorf("got = %q, want %q", got, want)
+	}
+}
+
 func TestShowOrig(t *testing.T) {
 	a, b := 1, 2
 

--- a/diff_test.go
+++ b/diff_test.go
@@ -319,7 +319,9 @@ func TestSliceType(t *testing.T) {
 	diff.Each(gotp.Printf, a, b)
 	want := "[]struct{}[2:3]: {{}} != {}\n"
 	if got != want {
-		t.Errorf("got = %q, want %q", got, want)
+		t.Errorf("bad diff")
+		t.Logf("got:\n%s", got)
+		t.Logf("want:\n%s", want)
 	}
 }
 


### PR DESCRIPTION
This commit fixes a bug where diff output for slice types was always
"string". It now shows the actual type of the slice.