### PR TITLE
remove redundant emitter type

### DIFF
--- a/text.go
+++ b/text.go
@@ -19,7 +19,7 @@ var (
 	visWS    = strings.NewReplacer(" ", "\u00b7", "\t", " \u2192 ")
 )
 
-func (d *differ) textDiff(e emitfer, t reflect.Type, a, b string) {
+func (d *differ) textDiff(e *emitter, t reflect.Type, a, b string) {
 	d.config.helper()
 
 	// TODO(kr): check for whitespace-only changes, use special format
@@ -55,7 +55,7 @@ func (d *differ) textDiff(e emitfer, t reflect.Type, a, b string) {
 	textDiffInline(e, t, a, b, as, bs)
 }
 
-func textDiffInline(e emitfer, t reflect.Type, a, b string, as, bs []string) {
+func textDiffInline(e *emitter, t reflect.Type, a, b string, as, bs []string) {
 	acut := accum(as)
 	bcut := accum(bs)
 	for _, ed := range diffseq.DiffSlice(as, bs) {


### PR DESCRIPTION
We don't need countEmitter; the same job can more easily be
done by a sink in the normal printEmitter, which is now
renamed to simply emitter. And now that there's only one
type of emitter, we don't need the interface type any more.

The downside is more garbage building paths and emitters
inside a call to equal.